### PR TITLE
Firebase auth loading and persistent

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -9,6 +9,7 @@ export default new Vuex.Store({
 
   state: {
     login: false,
+    loading: true,
   },
 
   mutations: {
@@ -21,6 +22,7 @@ export default new Vuex.Store({
     checkFirebaseLogin(state) {
       window.console.log('checkFirebaseLogin called');
       firebaseApp.auth().onAuthStateChanged((user) => {
+        state.loading = false;
         if (user) {
           window.console.log('login:' + user.displayName);
           state.login = true;
@@ -54,7 +56,13 @@ export default new Vuex.Store({
       window.console.log('logout');
       router.push('/');
     },
+
+    startLoading(state) {
+      state.loading = true;
+    },
+
   },
+
 
   actions: {},
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -24,6 +24,7 @@ export default new Vuex.Store({
         if (user) {
           window.console.log('login:' + user.displayName);
           state.login = true;
+          localStorage.uid = user.uid;
 
           window.console.log('set ' + user.uid);
           firebaseApp.firestore().collection('users').doc(user.uid).set({
@@ -49,6 +50,7 @@ export default new Vuex.Store({
       }
       firebaseApp.auth().signOut().catch((err) => window.console.log(err));
       state.login = false;
+      localStorage.removeItem('uid');
       window.console.log('logout');
       router.push('/');
     },

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -1,12 +1,18 @@
-<template>
-  <div>
+<template><main>
+
+  <div v-if="loading">
+    <h1 style="color:#fff;text-align:center;">LOADING...</h1>
+  </div>
+
+  <div v-else>
     <button @click="redirectGoogleAuth">Googleアカウントでログイン</button>
     <router-link to="/dice">ログインせずに試す</router-link>
   </div>
-</template>
+
+</main></template>
 
 <script lang="ts">
-  import {Component, Vue} from 'vue-property-decorator';
+  import {Component, Vue, Watch} from 'vue-property-decorator';
   import firebaseApp from '@/firebase';
   import * as firebase from 'firebase';
 
@@ -15,6 +21,7 @@
   })
 
   export default class Login extends Vue {
+
     // lifecycle hook
     public beforeCreate() {
       if (this.$store.state.login) { // ログイン済みの場合
@@ -24,11 +31,26 @@
 
     // methods
     public redirectGoogleAuth() {
+      this.$store.commit('startLoading');
       firebaseApp.auth().signInWithRedirect(new firebase.auth.GoogleAuthProvider())
         .catch((reason) => {
           alert(reason);
         });
     }
+
+    // computed
+    public get loading(): boolean {
+      return this.$store.state.loading;
+    }
+
+    // watcher
+    @Watch('loading')
+    public onChanged(newValue: boolean, oldValue: boolean): void {
+      if (this.$store.state.login) { // ログイン済みの場合
+        this.$router.push('/dice');
+      }
+    }
+
   }
 </script>
 


### PR DESCRIPTION
## LocalStrageにもログイン状態を保存し、そちらを優先して読むように処理を追加
- `.onAuthStateChanged`でもログイン状態を確認しているが遅いため、これだけだとログイン前の画面が一瞬見えてしまう

## ログイン時のローディング画面を追加
- 以下の2つのタイミングで/login画面をLOADING画面に変更し、操作をブロック
    - 「Googleでログイン」を押してリダイレクトするまでのタイミング
    - リダイレクト先で認証し戻ってきた後、認証が完了するまでの待ち時間
- 認証が完了した後は自動的に/loginから/diceへ遷移